### PR TITLE
Use official v6 tag with 'mvnArgs' support :back: 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,6 @@ on:
 
 jobs:
   build:
-    uses: axonivy-market/github-workflows/.github/workflows/release.yml@dev-release
+    uses: axonivy-market/github-workflows/.github/workflows/release.yml@v6
     with:
       mvnArgs: -DignoreSnapshots=true -DreleaseVersion=${{ inputs.releaseVersion }}


### PR DESCRIPTION
the 'mvnArgs' flag is now official support as 'v6' tag. So we go back to the stable train
https://github.com/axonivy-market/github-workflows/pull/57