### PR TITLE
AIAI-128 Expose warnings in Maven build to github actions :construction: 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,3 +10,7 @@ on:
 jobs:
   build:
     uses: axonivy-market/github-workflows/.github/workflows/ci.yml@v6
+    secrets:
+      mvnArgs: |
+       | sed -E "s|[0-9]. (WARNING) in ([^ ]*) \(at line ([0-9]+)\)(.*)|::\L\1 file=\2,line=\3::build issue\n\2@\3\4|g"\
+       | sed -E "s|\[WARNING\] |::warning::|g"

--- a/smart-orchestrator-test/.settings/org.eclipse.jdt.core.prefs
+++ b/smart-orchestrator-test/.settings/org.eclipse.jdt.core.prefs
@@ -5,5 +5,6 @@ org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
+org.eclipse.jdt.core.compiler.problem.unusedWarningToken=ignore
 org.eclipse.jdt.core.compiler.release=enabled
 org.eclipse.jdt.core.compiler.source=21

--- a/smart-orchestrator/.settings/org.eclipse.jdt.core.prefs
+++ b/smart-orchestrator/.settings/org.eclipse.jdt.core.prefs
@@ -5,5 +5,6 @@ org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
+org.eclipse.jdt.core.compiler.problem.unusedWarningToken=ignore
 org.eclipse.jdt.core.compiler.release=enabled
 org.eclipse.jdt.core.compiler.source=21


### PR DESCRIPTION
Let's keep an eye on code problems by blaming them on the actions overview (builds still pass)
<img width="1532" height="1077" alt="build-warnings-info" src="https://github.com/user-attachments/assets/db5d9ff0-6fa7-449d-a29e-2766d5db145d" />

Also these will be visible in the maven build output logs:
<img width="1499" height="1105" alt="build-warnings-log" src="https://github.com/user-attachments/assets/4a5bd33f-3788-47c8-ae1c-ad60593f743e" />
